### PR TITLE
README.md updated in order to improve Vagrant setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If something goes wrong, you can simply destroy and re-create it.
 mkdir <app-dir>
 cd <app-dir>
 vagrant init 99xt/MEANStack
-vagrant up --provider virtualbox
+vagrant up
 ```
 
 See the Vagrant Docs [here](https://www.vagrantup.com/docs/)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 If something goes wrong, you can simply destroy and re-create it.
 
+## Requirements
+
+* Download and install [Vagrant](https://www.vagrantup.com)
+* Download and install [VirtualBox](https://www.virtualbox.org/)
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![license](https://img.shields.io/github/license/99xt/vagrant-MEANStack.svg)](https://github.com/99xt/vagrant-MEANStack/blob/master/LICENSE)
 
-99xt/MEANStack is pre-packaged Vargrant box that provides you a solid development envirement for your MEAN-based apps without installing all those software packages, tools and a web server on your local machine. This intends to provide clean and synced development envirement between each team memebers and also between multiple computers when you work on the same project.
+99xt/MEANStack is pre-packaged Vagrant box that provides you a solid development enviroment for your MEAN-based apps without installing all those software packages, tools and a web server on your local machine. This intends to provide clean and synced development envorement between each team members and also between multiple computers when you work on the same project.
 
 If something goes wrong, you can simply destroy and re-create it.
 


### PR DESCRIPTION
#1 I fixed some typos on README.md introduction, added "Requirements" section with links to Vagrant/VirtualBox, and removed the explicit reference to provider during vagrant up since VirtualBox is default.